### PR TITLE
Various Fixes.

### DIFF
--- a/html/AssetTracker/Admin/Elements/ObjectCustomFields
+++ b/html/AssetTracker/Admin/Elements/ObjectCustomFields
@@ -90,15 +90,14 @@ if ($RT::VERSION =~ /^4/) {
     $ObjectTabs = "/Elements/Tabs";
 }
 elsif ($id) { 
-    $Object->Load($id) || Abort(loc("Couldn't load object [_1]", $id));
     $ObjectTabs = "/AssetTracker/Admin/Elements/${Type}Tabs";
 } else {
     $ObjectTabs = "/Admin/Elements/GlobalCustomFieldTabs";
-
 } 
 
 my $title; 
 if ($id) {
+$Object->Load($id) || Abort(loc("Couldn't load object [_1]", $id));
 $title =  loc('Edit Custom Fields for [_1]', $Object->Name);
 }
 elsif ($SubType) {

--- a/html/AssetTracker/Elements/AddLinks
+++ b/html/AssetTracker/Elements/AddLinks
@@ -45,8 +45,11 @@ if ($AssetString) {
             $Assets->Limit(FIELD => 'Type', VALUE => $type->Id) if $type->Id;
         }
     }
-    else {
+    elseif (($AssetField eq 'Name') or ($AssetField eq 'Description') or ($AssetField eq 'Status') ) {
         $Assets->Limit(FIELD => $AssetField, VALUE => $AssetString, OPERATOR => $AssetOp);
+    }
+    else {
+        $Assets->LimitCustomField(CUSTOMFIELD => $AssetField, VALUE => $AssetString, OPERATOR => $AssetOp );
     }
     $Assets->Limit(FIELD => 'Status', VALUE => 'retired', OPERATOR => '!=') unless $AllowRetired;
     #eliminate the assets own id

--- a/html/AssetTracker/Elements/SelectAssets
+++ b/html/AssetTracker/Elements/SelectAssets
@@ -48,7 +48,7 @@
 <option value="<% $col->[0] %>"><% loc($col->[1]) %>
 % }
 % while (my $CF = $CFs->Next) {
-<option value="CustomField-<% $CF->Id %>"><&|/l&>CustomField</&>: <% $CF->Name %>
+<option value="<% $CF->Id %>"><&|/l&>CustomField</&>: <% $CF->Name %>
 % }
 </select>
 <& /Elements/SelectMatch, Name=> 'AssetOp' &>

--- a/html/AssetTracker/Elements/SelectType
+++ b/html/AssetTracker/Elements/SelectType
@@ -62,8 +62,6 @@
 </LABEL>
 
 <%INIT>
-unless ($session{'see_in_types'}) { 
-
 @{$session{'see_in_types'}} = ();
 my $t=new RTx::AssetTracker::Types($session{'CurrentUser'});
 $t->UnLimit;
@@ -72,7 +70,6 @@ while (my $type=$t->Next) {
                 my $ds = { Name => $type->Name, Description => $type->Description, id => $type->id };
                 push (@{$session{'see_in_types'}}, $ds);
         }        
-}
 }
 </%INIT>
 

--- a/html/AssetTracker/Search/Bulk.html
+++ b/html/AssetTracker/Search/Bulk.html
@@ -117,7 +117,7 @@ while (my $Asset = $Assets->Next) {
 <TD VALIGN=TOP>
 <table>
 <tr><td class=label> <&|/l&>Make Description</&>: </td>
-<td class=value> <INPUT Name="Subject" SIZE=50> </td></tr>
+<td class=value> <INPUT Name="Description" SIZE=50> </td></tr>
 <tr><td class=label> <&|/l&>Make Type</&>: </td>
 <td class=value> <& /AssetTracker/Elements/SelectType, Name => "Type" &> </td></tr>
 <tr><td class=label> <&|/l&>Make Status</&>: </td>

--- a/html/Callbacks/AssetTracker/Elements/Tabs/Privileged
+++ b/html/Callbacks/AssetTracker/Elements/Tabs/Privileged
@@ -183,7 +183,7 @@ $assets->child( new => title => loc('New Search') => path => "/AssetTracker/Sear
 
         } else {
             $section = $tabs->child( select => title => loc('Asset Types'),
-                                     path => "/Admin/$type/" );
+                                     path => "/AssetTracker/Admin/$type/" );
         }
 
         $section->child( select => title => loc('Select'),

--- a/html/Callbacks/AssetTracker/Elements/Tabs/Privileged
+++ b/html/Callbacks/AssetTracker/Elements/Tabs/Privileged
@@ -208,12 +208,12 @@ $assets->child( new => title => loc('New Search') => path => "/AssetTracker/Sear
                               path => "/AssetTracker/Admin/Types/Templates.html?id=" . $id);
 
             $templates->child(select => title => loc('Select'), path => "/AssetTracker/Admin/Types/Templates.html?id=".$id);
-            $templates->child( create => title => loc('Create'), path => "/AssetTracker/Admin/Types/Template.html?Create=1;Queue=".$id);
+            $templates->child( create => title => loc('Create'), path => "/AssetTracker/Admin/Types/Template.html?Create=1;AssetType=".$id);
 
             my $scrips = $type->child( scrips => title => loc('Scrips'), path => "/AssetTracker/Admin/Types/Scrips.html?id=" . $id);
 
             $scrips->child( select => title => loc('Select'), path => "/AssetTracker/Admin/Types/Scrips.html?id=" . $id );
-            $scrips->child( create => title => loc('Create'), path => "/AssetTracker/Admin/Types/Scrip.html?Create=1;Queue=" . $id);
+            $scrips->child( create => title => loc('Create'), path => "/AssetTracker/Admin/Types/Scrip.html?Create=1;AssetType=" . $id);
 
             my $ticket_cfs = $type->child( 'ticket-custom-fields' => title => loc('Asset Custom Fields'),
                   path => '/AssetTracker/Admin/Types/CustomFields.html?SubType=RTx::AssetTracker::Asset&id=' . $id );

--- a/lib/RTx/AssetTracker/Transaction_Overlay.pm
+++ b/lib/RTx/AssetTracker/Transaction_Overlay.pm
@@ -725,8 +725,9 @@ sub AssetObj {
 
 sub OldValue {
     my $self = shift;
-    if (my $type = $self->__Value('ReferenceType')) {
-	my $Object = $type->new($self->CurrentUser);
+    if (my $type = $self->__Value('ReferenceType')
+       and my $id = $self->__Value('OldReference')) {
+ 	my $Object = $type->new($self->CurrentUser);
 	$Object->Load($self->__Value('OldReference'));
 	return $Object->Content;
     }
@@ -737,10 +738,11 @@ sub OldValue {
 
 sub NewValue {
     my $self = shift;
-    if (my $type = $self->__Value('ReferenceType')) {
-	my $Object = $type->new($self->CurrentUser);
-	$Object->Load($self->__Value('NewReference'));
-	return $Object->Content;
+    if (my $type = $self->__Value('ReferenceType')
+       and my $id = $self->__Value('NewReference') ) {
+        my $Object = $type->new($self->CurrentUser);
+        $Object->Load($self->__Value('NewReference'));
+        return $Object->Content;
     }
     else {
 	return $self->__Value('NewValue');
@@ -995,21 +997,25 @@ $_BriefDescriptions{CustomField} = sub {
         my $self = shift;
         my $field = $self->loc('CustomField');
 
+	$field = $self->loc('a custom field') if !defined($field);
+
         if ( $self->Field ) {
             my $cf = RT::CustomField->new( $self->CurrentUser );
             $cf->Load( $self->Field );
             $field = $cf->Name();
         }
 
-        if ( (not defined $self->OldValue) or ($self->OldValue eq '') ) {
-            return ( $self->loc("[_1] [_2] added", $field, $self->NewValue) );
-        }
-        elsif ( (not defined $self->NewValue) or ($self->NewValue eq '') ) {
-            return ( $self->loc("[_1] [_2] deleted", $field, $self->OldValue) );
+        my $new = $self->NewValue;
+        my $old = $self->OldValue;
 
+        if ( !defined($old) || $old eq '' ) {
+            return $self->loc("[_1] [_2] added", $field, $new);
+        }
+        elsif ( !defined($new) || $new eq '' ) {
+            return $self->loc("[_1] [_2] deleted", $field, $old);
         }
         else {
-            return $self->loc("[_1] [_2] changed to [_3]", $field, $self->OldValue, $self->NewValue );
+            return $self->loc("[_1] [_2] changed to [_3]", $field, $old, $new);
         }
     };
 


### PR DESCRIPTION
ISSUE 13 - "Searching by Custom Fields ... does not work"

https://github.com/chakatodd/rt-extension-assettracker/issues/13

Note: I chose to change ELEMENTS to conform to what Assets_Overlay.pm expected.  I thought that was less invasive.  Other solutions are obviously possible.

ISSUE 9 - "Asset History Breaks"

https://github.com/chakatodd/rt-extension-assettracker/issues/9

Fix ISSUE #14 - "Error 'Type not found' when trying to create Templates & Scrips

https://github.com/chakatodd/rt-extension-assettracker/issues/14

Fix ISSUE # 15 - "Broken Link to 'Asset Types' in Admin Menu"   

https://github.com/chakatodd/rt-extension-assettracker/issues/15

Fix ISSUE #16 - Asset Object not loading to associate CUSTOM FIELDS.    

https://github.com/chakatodd/rt-extension-assettracker/issues/16

Fix issue 17 - "Asset Types not showing up..."  

https://github.com/chakatodd/rt-extension-assettracker/issues/17

Fix Issue 18 - "Batch/Bulk update doesn't update Description"

https://github.com/chakatodd/rt-extension-assettracker/issues/18
