### PR TITLE
Errors when clicking "Show Results"

### DIFF
--- a/html/AssetTracker/Search/Results.html
+++ b/html/AssetTracker/Search/Results.html
@@ -87,6 +87,9 @@
 <& /Elements/Callback, _CallbackName => 'SearchActions', QueryString => $QueryString&>
 </div>
 <%INIT>
+
+$Page = 1 unless $Page && $Page > 0;
+
 my ($title, $assetcount);
 $session{'i'}++;
 $session{'assets'} = RTx::AssetTracker::Assets->new($session{'CurrentUser'}) ;
@@ -97,6 +100,7 @@ $session{'assets'}->OrderBy(FIELD => $OrderBy, ORDER => $Order);
 $session{'CurrentAssetSearchHash'} = {
     Format      => $Format,
     Query       => $Query,
+    Page        => $Page,
     Order       => $Order,
     OrderBy     => $OrderBy,
     RowsPerPage => $Rows,

--- a/html/Callbacks/AssetTracker/Elements/Tabs/Privileged
+++ b/html/Callbacks/AssetTracker/Elements/Tabs/Privileged
@@ -99,7 +99,7 @@ $assets->child( new => title => loc('New Search') => path => "/AssetTracker/Sear
         my $search = $assets; #->child('search');
         my $args      = '';
         my $has_query = '';
-        my $current_search = $session{"CurrentSearchHash"} || {};
+        my $current_search = $session{"CurrentAssetSearchHash"} || {};
         my $search_id = $m->request_args->{'SavedSearchLoad'} || $m->request_args->{'SavedSearchId'} || $search->{'SearchId'} || '';
 
         $has_query = 1 if ( $m->request_args->{'Query'} or $current_search->{'Query'} );

--- a/html/Search/Asset.html
+++ b/html/Search/Asset.html
@@ -1,1 +1,5 @@
-<& /AssetTracker/Search/Results.html, %ARGS &>
+<%init>
+RT::Interface::Web::Redirect(RT->Config->Get('WebURL').
+        'AssetTracker/Search/Results.html?' . $m->comp( '/Elements/QueryString',
+            %ARGS, Load => 'Load', CurrentSearch => $ARGS{LoadSavedSearch} ) );
+</%init>

--- a/lib/RTx/AssetTracker/Assets_Overlay.pm
+++ b/lib/RTx/AssetTracker/Assets_Overlay.pm
@@ -1442,6 +1442,26 @@ sub LimitStatus {
 
 # }}}
 
+=head2 IgnoreType
+
+Stub. AT doesn't use this flag because assets don't have an equivalent
+to "ticket types")
+
+=cut
+
+sub IgnoreType {
+    my $self = shift;
+
+    # Instead of faking a Limit that later gets ignored, fake up the
+    # fact that we're already looking at type, so that the check in
+    # Tickets_SQL/FromSQL goes down the right branch
+
+    #  $self->LimitType(VALUE => '__any');
+    #$self->{looking_at_type} = 1;
+}
+
+
+
 # {{{ sub LimitDescription
 
 =head2 LimitDescription


### PR DESCRIPTION
After successfully running an Asset query, if one later needs to re-display the results, by clicking "Show Results", you will sometimes get a blank page, sometimes get an error message "Can't locate object method "IgnoreType" via package "RTx::AssetTracker::Assets" at /usr/share/request-tracker4/lib/RT/Record.pm line 1054." and sometimes get results using the wrong format string (the format string from your last search of Tickets)
This should resolve all these issues.
