### PR TITLE
Show the correct txn link in asset histories

### DIFF
--- a/html/AssetTracker/Asset/Display.html
+++ b/html/AssetTracker/Asset/Display.html
@@ -64,7 +64,7 @@
       Ticket => $AssetObj, 
       Tickets => $Assets, 
       ShowDisplayModes => 0,
-      MaxRows => $RT::ShowAssetHistory
+      DisplayPath => RT->Config->Get('WebPath')."/AssetTracker/Asset/Display.html?id=".$AssetObj->id
       &> 
 % }
 

--- a/html/AssetTracker/Asset/History.html
+++ b/html/AssetTracker/Asset/History.html
@@ -52,7 +52,8 @@
       
 <& /Ticket/Elements/ShowHistory , 
     Ticket => $Asset, 
-    ShowDisplayModes => 0
+    ShowDisplayModes => 0,
+    DisplayPath => RT->Config->Get('WebPath')."/AssetTracker/Asset/Display.html?id=".$Asset->id
     &> 
 
 


### PR DESCRIPTION
I thought I had this fixed but I guess not. The # links in history was linking to tickets instead of assets. User and group histories in RT still have the same problem.
Also the MaxRows option doesn't exist any more.
