### PR TITLE
Use correct lookuptype for assets

### DIFF
--- a/lib/RT/Transaction_Vendor.pm
+++ b/lib/RT/Transaction_Vendor.pm
@@ -166,4 +166,23 @@ $_BriefDescriptions{Set} = sub {
 };
 
 
+=head2 CustomFieldLookupType
+
+Returns the RT::Transaction lookup type, which can 
+be passed to RT::CustomField->Create() via the 'LookupType' hash key.
+
+=cut
+
+
+sub CustomFieldLookupType {
+    my $self=shift;
+    
+    if ( $self->{values}->{objecttype} eq 'RTx::AssetTracker::Asset' ) {
+	"RTx::AssetTracker::Type-RTx::AssetTracker::Asset-RT::Transaction";
+    } else {
+	"RT::Queue-RT::Ticket-RT::Transaction";
+    }
+}
+
+
 1;


### PR DESCRIPTION
Override RT::Transaction::CustomFieldLookupType function to give the correct lookup type when it's an asset transaction.
